### PR TITLE
CI: Fix some issues pointed out by zizmor

### DIFF
--- a/.github/workflows/build-dumb-pypi.yml
+++ b/.github/workflows/build-dumb-pypi.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           ref: main
           repository: ansible-community/antsibull-build
+          persist-credentials: false
 
       - name: >-
           Check out ${{
@@ -102,6 +103,7 @@ jobs:
           path: ansible-build-data
           ref: ${{ steps.build-settings.outputs.ansible-build-data-ref }}
           repository: ${{ steps.build-settings.outputs.ansible-build-data-slug }}
+          persist-credentials: false
 
       - name: Make 'dist/' dir
         run: |
@@ -156,6 +158,7 @@ jobs:
           path: ansible--ansible--devel
           ref: ${{ steps.build-settings.outputs.ansible-core-ref }}
           repository: ${{ steps.build-settings.outputs.ansible-core-slug }}
+          persist-credentials: false
 
       - name: >-
           Build ${{


### PR DESCRIPTION
Fix some issues in GHA workflows pointed out by zizmor (https://github.com/woodruffw/zizmor).

Some more issues are pointed out:
```
error[excessive-permissions]: overly broad workflow or job-level permissions
  --> /home/felix/projects/code/github-cloned/antsibull-nightly-builds/.github/workflows/build-dumb-pypi.yml:38:1
   |
38 | / permissions:
39 | |   contents: read
40 | |   pages: write
41 | |   id-token: write
   | |_________________^ pages: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[excessive-permissions]: overly broad workflow or job-level permissions
  --> /home/felix/projects/code/github-cloned/antsibull-nightly-builds/.github/workflows/build-dumb-pypi.yml:38:1
   |
38 | / permissions:
39 | |   contents: read
40 | |   pages: write
41 | |   id-token: write
   | |_________________^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High
```
If someone else wants to work on them, feel free!